### PR TITLE
Add string serializer and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,10 @@ There's a sample React app in `examples/counter`. To start it:
 
 * Async/await?
 * Middleware?
+
+## Contributing
+
+1. Fork the repo, clone it, and cd into the directory.
+1. Use Node 8 (`nvm use`) and install packages (`yarn`)
+1. Add your feature... and, of course, a test for it.
+1. Run tests with `yarn test`

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import createStore from './createStore'
 import createFakeStore from './fakes/createFakeStore'
 import DateSerializer from './serializers/dateSerializer'
 import JsonSerializer from './serializers/jsonSerializer'
+import StringSerializer from './serializers/stringSerializer'
 import { Provider, connect } from './react'
 
 export {
@@ -9,6 +10,7 @@ export {
   createFakeStore,
   DateSerializer,
   JsonSerializer,
+  StringSerializer,
   Provider,
   connect,
 }

--- a/src/serializers/stringSerailizer.spec.js
+++ b/src/serializers/stringSerailizer.spec.js
@@ -1,0 +1,24 @@
+import StringSerializer from './stringSerializer'
+
+describe('StringSerializer', () => {
+  const TEST_STRING = 'myMessage'
+  const TEST_RESULT = TEST_STRING.toString()
+  const NULL_THING = null
+  const NULL_RESULT = ''
+
+  describe('serialize', () => {
+    it('serializes a value into a string', () => {
+      expect(StringSerializer.serialize(TEST_STRING)).toEqual(TEST_RESULT)
+    })
+
+    it('serializes non-string values correctly', () => {
+      expect(StringSerializer.serialize(NULL_THING)).toEqual(NULL_RESULT)
+    })
+  })
+
+  describe('deserialize', () => {
+    it('deserializes a string into a string', () => {
+      expect(StringSerializer.deserialize(TEST_RESULT)).toEqual(TEST_STRING)
+    })
+  })
+})

--- a/src/serializers/stringSerializer.js
+++ b/src/serializers/stringSerializer.js
@@ -1,0 +1,10 @@
+export default {
+  deserialize: string => string,
+  serialize: val => {
+    try {
+      return val.toString()
+    } catch (e) {
+      return ''
+    }
+  }
+}


### PR DESCRIPTION
Added a string serializer. It occurred to me that if `val` is null or otherwise not defined, the code as it was originally (where the `serialize` method simply returned `val.toString()`) would throw an error. (Null does not have a `toString` method)

Not sure if I picked the right solution. At first I tried to fix the issue so that an error thrown would result in `''` (empty string), but that honestly seemed more likely to mislead people. So instead I literally interpolate whatever value. However... that seems like it could be a major security flaw. So. Your thoughts?