### PR TITLE
Properly handle serialization errors

### DIFF
--- a/src/serializers/jsonSerializer.js
+++ b/src/serializers/jsonSerializer.js
@@ -1,6 +1,10 @@
 export default {
   deserialize: jsonString => {
-    return JSON.parse(jsonString)
+    try {
+      return JSON.parse(jsonString)
+    } catch (err) {
+      return null
+    }
   },
   serialize: val => {
     return JSON.stringify(val)

--- a/src/serializers/jsonSerializer.spec.js
+++ b/src/serializers/jsonSerializer.spec.js
@@ -3,6 +3,7 @@ import JsonSerializer from './jsonSerializer'
 describe('JsonSerializer', () => {
   const TEST_OBJECT = { test: 'value' }
   const TEST_JSON = JSON.stringify(TEST_OBJECT)
+  const INVALID_JSON = '{"test":"value"' // NO CLOSING BRACE!
 
   describe('serialize', () => {
     it('serializes a value into JSON', () => {
@@ -13,6 +14,12 @@ describe('JsonSerializer', () => {
   describe('deserialize', () => {
     it('deserializes a JSON string into a value', () => {
       expect(JsonSerializer.deserialize(TEST_JSON)).toEqual(TEST_OBJECT)
+    })
+
+    describe('when the input is not valid JSON', () => {
+      it('returns null', () => {
+        expect(JsonSerializer.deserialize(INVALID_JSON)).toBeNull()
+      })
     })
   })
 })

--- a/src/store.js
+++ b/src/store.js
@@ -93,11 +93,15 @@ export default class Store {
       throw new Error(`No serializer registered for key ${key}`)
     }
 
-    const deserializedValue = serializer.deserialize(value)
+    try {
+      const deserializedValue = serializer.deserialize(value)
 
-    return deserializedValue === undefined || deserializedValue === null
-      ? null
-      : deserializedValue
+      return deserializedValue === undefined || deserializedValue === null
+        ? null
+        : deserializedValue
+    } catch (err) {
+      return null
+    }
   }
 
   _serialize(key, value) {
@@ -111,6 +115,10 @@ export default class Store {
       throw new Error(`No serializer registered for key ${key}`)
     }
 
-    return serializer.serialize(value)
+    try {
+      return serializer.serialize(value)
+    } catch (err) {
+      return null
+    }
   }
 }

--- a/src/store.spec.js
+++ b/src/store.spec.js
@@ -266,6 +266,18 @@ describe('Store', () => {
           expect(store._deserialize(TEST_KEY, TEST_VALUE)).toEqual(TEST_VALUE)
         })
       })
+
+      describe('when the serializer throws an error', () => {
+        beforeEach(() => {
+          mockSerializer.deserialize.mockImplementation(() => {
+            throw new Error('YOU DID A BAD THING')
+          })
+        })
+
+        it('returns null', () => {
+          expect(store._deserialize(TEST_KEY, TEST_VALUE)).toBeNull()
+        })
+      })
     })
   })
 
@@ -306,6 +318,18 @@ describe('Store', () => {
         store._serialize(TEST_KEY, TEST_VALUE)
 
         expect(mockSerializer.serialize.mock.calls.length).toBe(1)
+      })
+    })
+
+    describe('when the serializer throws an error', () => {
+      beforeEach(() => {
+        mockSerializer.serialize.mockImplementation(() => {
+          throw new Error('YOU DID A BAD THING')
+        })
+      })
+
+      it('returns null', () => {
+        expect(store._serialize(TEST_KEY, TEST_VALUE)).toBeNull()
       })
     })
   })


### PR DESCRIPTION
This PR changes Rehash to properly handle errors originating from the serializer. It also fixes the JSON serializer specifically to properly handle JSON deserialization errors.

Fixes #11 