### PR TITLE
Use encodeUriComponent instead of encodeUri

### DIFF
--- a/src/hashRepository.js
+++ b/src/hashRepository.js
@@ -34,7 +34,7 @@ export default class HashRepository {
   _buildFragment(path, state) {
     const hashString = Object.entries(state)
       .filter(([key, value]) => !(value === null || value === undefined))
-      .map(p => `${p[0]}=${encodeURI(p[1])}`)
+      .map(p => `${p[0]}=${encodeURIComponent(p[1])}`)
       .join('&')
 
     return `#${path}?${hashString}`

--- a/src/hashRepository.spec.js
+++ b/src/hashRepository.spec.js
@@ -129,5 +129,20 @@ describe('HashRepository', () => {
         expect(() => repo.set({ [UNMANAGED_KEY]: UNMANAGED_VALUE })).toThrow()
       })
     })
+
+    describe('when value is url', () => {
+      it('works', () => {
+        const testValue = 'https://my.asosservices.com/api/marketing/a-list/v2/customer/201635233/details?a=b'
+        repo.set({
+          [TEST_KEY]: testValue,
+        })
+        expect(
+          global.location.hash.includes(
+            'https%3A%2F%2Fmy.asosservices.com%2Fapi%2Fmarketing%2Fa-list%2Fv2%2Fcustomer%2F201635233%2Fdetails%3Fa%3Db',
+          ),
+        )
+        expect(repo.get()[TEST_KEY]).toEqual(testValue)
+      })
+    })
   })
 })

--- a/src/util/hashParseUtils.js
+++ b/src/util/hashParseUtils.js
@@ -9,7 +9,7 @@ export const parseQueryString = queryString => {
     .split('&') // extract pairs
     .reduce((acc, next) => {
       const [key, val] = next.split('=')
-      acc[key] = decodeURI(val)
+      acc[key] = decodeURIComponent(val)
       return acc
     }, {})
 }


### PR DESCRIPTION
This fixes the case when a value in the hash is a URL that includes query params.